### PR TITLE
allow full mic device name, as prefix is changing from plughw to hw

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,13 @@ function PocketSphinxContinuous(config) {
 
 PocketSphinxContinuous.prototype.start = function() {
   if (!this.isListening()) {
+    let mic=this.microphone;
+    // if name starts with number
+    if (this.microphone.match(/^\d/))
+      mic = 'plughw:'+this.microphone;      
     this._psc = spawn('pocketsphinx_continuous', [
       '-adcdev',
-      `plughw:${this.microphone}`,
+      mic,
       '-inmic',
       'yes',
       '-lm',


### PR DESCRIPTION
allow user to specify full mic device name  to bypass naming changes